### PR TITLE
2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.0
+
+- Updated SDK lower-bound to 3.0
+- Removed `always_require_non_null_named_parameters` from `recommended.yaml`
+  as it is only relevant in Dart pre 2.12 and with Dart 3.0, libraries can
+  no longer be opted back that far.
+
 ## 2.0.1
 
 - Updated documentation for the `lib/core.yaml` and `lib/recommended.yaml`

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -11,7 +11,6 @@ include: package:lints/core.yaml
 
 linter:
   rules:
-    - always_require_non_null_named_parameters
     - annotate_overrides
     - avoid_function_literals_in_foreach_calls
     - avoid_init_to_null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: lints
-version: 2.0.1
+version: 2.1.0
 description: >
   Official Dart lint rules. Defines the 'core' and 'recommended' set of lints
   suggested by the Dart team.
 repository: https://github.com/dart-lang/lints
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ^3.0.0
 
 # NOTE: Code is not allowed in this package. Do not add dependencies.
 # dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
 repository: https://github.com/dart-lang/lints
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.0.0-417
 
 # NOTE: Code is not allowed in this package. Do not add dependencies.
 # dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
 repository: https://github.com/dart-lang/lints
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.0.0
 
 # NOTE: Code is not allowed in this package. Do not add dependencies.
 # dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
 repository: https://github.com/dart-lang/lints
 
 environment:
-  sdk: ^3.0.0
+  sdk: '>=3.0.0 <4.0.0'
 
 # NOTE: Code is not allowed in this package. Do not add dependencies.
 # dependencies:


### PR DESCRIPTION
Creates a new release for Dart 3.0, that removes `always_require_non_null_named_parameters` as per #95.

/cc @goderbauer @mit-mit @jakemac53 @natebosch @bwilkerson 