### PR TITLE
Add topics to the pubspec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1-dev
+
+- Added the `analysis` and `lints` topics to the pubspec file.
+
 ## 2.1.0
 
 - Updated SDK lower-bound to 3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,13 @@
 name: lints
-version: 2.1.0
+version: 2.1.1-dev
 description: >
   Official Dart lint rules. Defines the 'core' and 'recommended' set of lints
   suggested by the Dart team.
 repository: https://github.com/dart-lang/lints
+
+topics:
+  - analysis
+  - lints
 
 environment:
   sdk: ^3.0.0-417


### PR DESCRIPTION
I couldn't decide between `lints` or `linter-rules`, but decided `lints` being nice and short won me over.