### PR TITLE
Remove pedantic from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,23 +65,6 @@ You can customize the predefined lint sets, both to disable one or more of the
 lints included, or to add additional lints. For details see [customizing static
 analysis].
 
-## Migrating from `package:pedantic`
-
-In migrating from the predefined lint sets provided by the [`package:pedantic`],
-you get static analysis coverage from 29 additional lints. There are, however,
-6 lints which the pedantic package includes which are not included in the
-predefined lint sets provided by the lints package:
-`always_declare_return_types`, `prefer_single_quotes`,
-`sort_child_properties_last`, `unawaited_futures`, `unsafe_html`, and
-`use_full_hex_values_for_flutter_colors` (also included in
-[`package:flutter_lints`]). To keep any of these lints enabled,
-add them to your [analysis options][customizing static analysis].
-
-Additionally, `package:pedantic` provides the `unawaited` method for use with
-`unawaited_futures`. With SDK version 2.14 this method is available in the
-`dart:async` package, and this is now the recommended way to use it. Be sure to
-mark the minimum SDK version of your package as `2.14` if you do so.
-
 ## Evolving the lint sets
 
 The Dart language changes and the ecosystem continues to develop new best 


### PR DESCRIPTION
It's been over 2 years since this package has replaced pedantic, the lint amount specified is no longer accurate, and the 2.14 SDK mention isn't relevant anymore with the minimum SDK constraint being 3.0.0 now.

We could update it, but I'm not sure there is much value coming from this section anymore. Let me know what you think :)