### PR TITLE
add collection_methods_unrelated_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0-wip
+## 2.1.1-dev
 
 - Added the `analysis` and `lints` topics to the pubspec file.
 - Added `collection_methods_unrelated_type` to core (available since 2.19).
@@ -7,7 +7,7 @@
 
 ## 2.1.0
 
-- Updated SDK lower-bound to 3.0.
+- Updated SDK lower-bound to 3.0
 - Removed `always_require_non_null_named_parameters` from `recommended.yaml`
   as it is only relevant in Dart pre 2.12 and with Dart 3.0, libraries can
   no longer be opted back that far.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-## 2.1.1-dev
+## 2.2.0-wip
 
 - Added the `analysis` and `lints` topics to the pubspec file.
+- Added `collection_methods_unrelated_type` to core (available since 2.19).
+- Removed `iterable_contains_unrelated_type` from core (deprecated in 3.1).
+- Removed `list_remove_unrelated_type` from core (deprecated in 3.1).
 
 ## 2.1.0
 
-- Updated SDK lower-bound to 3.0
+- Updated SDK lower-bound to 3.0.
 - Removed `always_require_non_null_named_parameters` from `recommended.yaml`
   as it is only relevant in Dart pre 2.12 and with Dart 3.0, libraries can
   no longer be opted back that far.

--- a/README.md
+++ b/README.md
@@ -109,13 +109,12 @@ To use these lints create an `analysis_options.yaml` file with:
 | [`await_only_futures`](https://dart.dev/lints/await_only_futures) | Await only futures. |
 | [`camel_case_extensions`](https://dart.dev/lints/camel_case_extensions) | Name extensions using UpperCamelCase. |
 | [`camel_case_types`](https://dart.dev/lints/camel_case_types) | Name types using UpperCamelCase. |
+| [`collection_methods_unrelated_type`](https://dart.dev/lints/collection_methods_unrelated_type) | Invocation of various collection methods with arguments of unrelated types. |
 | [`curly_braces_in_flow_control_structures`](https://dart.dev/lints/curly_braces_in_flow_control_structures) | DO use curly braces for all flow control structures. |
 | [`depend_on_referenced_packages`](https://dart.dev/lints/depend_on_referenced_packages) | Depend on referenced packages. |
 | [`empty_catches`](https://dart.dev/lints/empty_catches) | Avoid empty catch blocks. |
 | [`file_names`](https://dart.dev/lints/file_names) | Name source files using `lowercase_with_underscores`. |
 | [`hash_and_equals`](https://dart.dev/lints/hash_and_equals) | Always override `hashCode` if overriding `==`. |
-| [`iterable_contains_unrelated_type`](https://dart.dev/lints/iterable_contains_unrelated_type) | Invocation of Iterable<E>.contains with references of unrelated types. |
-| [`list_remove_unrelated_type`](https://dart.dev/lints/list_remove_unrelated_type) | Invocation of `remove` with references of unrelated types. |
 | [`no_duplicate_case_values`](https://dart.dev/lints/no_duplicate_case_values) | Don't use more than one case with same value. |
 | [`non_constant_identifier_names`](https://dart.dev/lints/non_constant_identifier_names) | Name non-constant identifiers using lowerCamelCase. |
 | [`null_check_on_nullable_type_parameter`](https://dart.dev/lints/null_check_on_nullable_type_parameter) | Don't use null check on a potentially nullable type parameter. |

--- a/lib/core.yaml
+++ b/lib/core.yaml
@@ -13,13 +13,12 @@ linter:
     - await_only_futures
     - camel_case_extensions
     - camel_case_types
+    - collection_methods_unrelated_type
     - curly_braces_in_flow_control_structures
     - depend_on_referenced_packages
     - empty_catches
     - file_names
     - hash_and_equals
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
     - no_duplicate_case_values
     - non_constant_identifier_names
     - null_check_on_nullable_type_parameter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lints
-version: 2.1.1-dev
+version: 2.2.0-wip
 description: >
   Official Dart lint rules. Defines the 'core' and 'recommended' set of lints
   suggested by the Dart team.
@@ -10,7 +10,7 @@ topics:
   - lints
 
 environment:
-  sdk: ^3.0.0-417
+  sdk: ^3.0.0
 
 # NOTE: Code is not allowed in this package. Do not add dependencies.
 # dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lints
-version: 2.2.0-wip
+version: 2.1.1-dev
 description: >
   Official Dart lint rules. Defines the 'core' and 'recommended' set of lints
   suggested by the Dart team.
@@ -10,7 +10,7 @@ topics:
   - lints
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.0.0-417
 
 # NOTE: Code is not allowed in this package. Do not add dependencies.
 # dependencies:


### PR DESCRIPTION
- added `collection_methods_unrelated_type` to core (available since 2.19)
- removed `iterable_contains_unrelated_type` from core (deprecated in 3.1)
- removed `list_remove_unrelated_type` from core (deprecated in 3.1)

See also https://github.com/dart-lang/lints/issues/118.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
  
