### PR TITLE
Fix typo in 3.0.0-wip changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 ## 3.0.0-wip
 
-- Added to core.yaml:
+- Added to `core.yaml`:
     - `collection_methods_unrelated_type`
     - `implicit_call_tearoffs`
     - `use_string_in_part_of_directives`
-- Removed from core.yaml:
+- Removed from `core.yaml`:
     - `iterable_contains_unrelated_type`
     - `list_remove_unrelated_type`
-- Add info about which lints have quick fixs to the package's readme.
+- Add info about which lints have quick fixes to the package's readme.
 
 ## 2.1.1
 


### PR DESCRIPTION
Also updates the file names to code syntax to be consistent with previous changelog entries.
