### PR TITLE
Remove `prefer_equal_for_default_values` from recommended set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Removed from `core.yaml`:
     - `iterable_contains_unrelated_type`
     - `list_remove_unrelated_type`
+- Removed from `recommended.yaml`:
+    - `deprecated_colon_for_default_value`
 - Add info about which lints have quick fixes to the package's readme.
 
 ## 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     - `iterable_contains_unrelated_type`
     - `list_remove_unrelated_type`
 - Removed from `recommended.yaml`:
-    - `deprecated_colon_for_default_value`
+    - `prefer_equal_for_default_values`
 - Add info about which lints have quick fixes to the package's readme.
 
 ## 2.1.1

--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ To use these lints create an `analysis_options.yaml` file with:
 | [`prefer_collection_literals`](https://dart.dev/lints/prefer_collection_literals) | Use collection literals when possible. | ✅ |
 | [`prefer_conditional_assignment`](https://dart.dev/lints/prefer_conditional_assignment) | Prefer using `??=` over testing for null. | ✅ |
 | [`prefer_contains`](https://dart.dev/lints/prefer_contains) | Use contains for `List` and `String` instances. | ✅ |
-| [`prefer_equal_for_default_values`](https://dart.dev/lints/prefer_equal_for_default_values) | Use `=` to separate a named parameter from its default value. |  |
 | [`prefer_final_fields`](https://dart.dev/lints/prefer_final_fields) | Private field could be final. | ✅ |
 | [`prefer_for_elements_to_map_fromIterable`](https://dart.dev/lints/prefer_for_elements_to_map_fromIterable) | Prefer 'for' elements when building maps from iterables. | ✅ |
 | [`prefer_function_declarations_over_variables`](https://dart.dev/lints/prefer_function_declarations_over_variables) | Use a function declaration to bind a function to a name. | ✅ |

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -37,7 +37,6 @@ linter:
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_for_elements_to_map_fromIterable
     - prefer_function_declarations_over_variables


### PR DESCRIPTION
Now that the package requires SDK `^3.0.0`, this lint does nothing since it's not reported by the Dart 3 SDK, which instead reports the [`deprecated_colon_for_default_value`](https://dart.dev/tools/diagnostic-messages#deprecated_colon_for_default_value) diagnostic for 2.12-2.19 language versions.

Closes https://github.com/dart-lang/lints/issues/143