### PR TITLE
add dangling_library_doc_comments, remove prefer_void_to_null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.0.0-beta.2
 
+- Add `dangling_library_doc_comments` to core.
 - Remove `no_wildcard_variable_uses` from core.
+- Remove `prefer_void_to_null` from recommended.
 
 ## 3.0.0-beta
 

--- a/lib/core.yaml
+++ b/lib/core.yaml
@@ -15,6 +15,7 @@ linter:
     - camel_case_types
     - collection_methods_unrelated_type
     - curly_braces_in_flow_control_structures
+    - dangling_library_doc_comments
     - depend_on_referenced_packages
     - empty_catches
     - file_names

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -47,7 +47,6 @@ linter:
     - prefer_is_not_operator
     - prefer_null_aware_operators
     - prefer_spread_collections
-    - prefer_void_to_null
     - recursive_getters
     - slash_for_doc_comments
     - type_init_formals

--- a/rules.md
+++ b/rules.md
@@ -14,6 +14,7 @@
 | [`camel_case_types`](https://dart.dev/lints/camel_case_types) | Name types using UpperCamelCase. |  |
 | [`collection_methods_unrelated_type`](https://dart.dev/lints/collection_methods_unrelated_type) | Invocation of various collection methods with arguments of unrelated types. |  |
 | [`curly_braces_in_flow_control_structures`](https://dart.dev/lints/curly_braces_in_flow_control_structures) | DO use curly braces for all flow control structures. | ✅ |
+| [`dangling_library_doc_comments`](https://dart.dev/lints/dangling_library_doc_comments) | Attach library doc comments to library directives. | ✅ |
 | [`depend_on_referenced_packages`](https://dart.dev/lints/depend_on_referenced_packages) | Depend on referenced packages. |  |
 | [`empty_catches`](https://dart.dev/lints/empty_catches) | Avoid empty catch blocks. | ✅ |
 | [`file_names`](https://dart.dev/lints/file_names) | Name source files using `lowercase_with_underscores`. |  |
@@ -79,7 +80,6 @@
 | [`prefer_is_not_operator`](https://dart.dev/lints/prefer_is_not_operator) | Prefer is! operator. | ✅ |
 | [`prefer_null_aware_operators`](https://dart.dev/lints/prefer_null_aware_operators) | Prefer using null aware operators. | ✅ |
 | [`prefer_spread_collections`](https://dart.dev/lints/prefer_spread_collections) | Use spread collections when possible. | ✅ |
-| [`prefer_void_to_null`](https://dart.dev/lints/prefer_void_to_null) | Don't use the Null type, unless you are positive that you don't want void. | ✅ |
 | [`recursive_getters`](https://dart.dev/lints/recursive_getters) | Property getter recursively returns itself. |  |
 | [`slash_for_doc_comments`](https://dart.dev/lints/slash_for_doc_comments) | Prefer using /// for doc comments. | ✅ |
 | [`type_init_formals`](https://dart.dev/lints/type_init_formals) | Don't type annotate initializing formals. | ✅ |


### PR DESCRIPTION
- add `dangling_library_doc_comments` to core (#148)
- remove `prefer_void_to_null` from recommended (#154)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
