### PR TITLE
Remove mention of `no_wildcard_variable_uses` from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
   - added `use_string_in_part_of_directives`
   - removed `iterable_contains_unrelated_type`
   - removed `list_remove_unrelated_type`
-  - removed `no_wildcard_variable_uses`
 - `recommended`:
   - added `unnecessary_to_list_in_spreads`
   - added `use_super_parameters`

--- a/tool/rules.json
+++ b/tool/rules.json
@@ -45,6 +45,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "avoid_unstable_final_fields",
+    "description": "Avoid overriding a final field to return different values if called multiple times.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "avoid_web_libraries_in_flutter",
     "description": "Avoid using web-only libraries outside Flutter web plugin packages.",
     "fixStatus": "noFix"


### PR DESCRIPTION
The lint was never included in a stable release, so it doesn't need to be in the changelog.

Including it in the changelog as removed incorrectly makes it seem like the lint is being removed or isn't good.