### PR TITLE
remove the 'library_names' lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   - added `library_annotations` (https://github.com/dart-lang/lints/issues/177)
   - added `no_wildcard_variable_uses` (https://github.com/dart-lang/lints/issues/139)
   - removed `package_prefixed_library_names` (https://github.com/dart-lang/lints/issues/172)
+- `recommended`:
+  - removed `library_names` (https://github.com/dart-lang/lints/issues/181)
 - Updated the SDK lower-bound to 3.1.
 - Add a section on upgrading to the latest lint set to the readme.
 

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -25,7 +25,6 @@ linter:
     - empty_statements
     - exhaustive_cases
     - implementation_imports
-    - library_names
     - library_prefixes
     - library_private_types_in_public_api
     - no_leading_underscores_for_library_prefixes

--- a/rules.md
+++ b/rules.md
@@ -59,7 +59,6 @@
 | [`empty_statements`](https://dart.dev/lints/empty_statements) | Avoid empty statements. | ✅ |
 | [`exhaustive_cases`](https://dart.dev/lints/exhaustive_cases) | Define case clauses for all constants in enum-like classes. | ✅ |
 | [`implementation_imports`](https://dart.dev/lints/implementation_imports) | Don't import implementation files from another package. |  |
-| [`library_names`](https://dart.dev/lints/library_names) | Name libraries using `lowercase_with_underscores`. |  |
 | [`library_prefixes`](https://dart.dev/lints/library_prefixes) | Use `lowercase_with_underscores` when specifying a library prefix. |  |
 | [`library_private_types_in_public_api`](https://dart.dev/lints/library_private_types_in_public_api) | Avoid using private types in public APIs. |  |
 | [`no_leading_underscores_for_library_prefixes`](https://dart.dev/lints/no_leading_underscores_for_library_prefixes) | Avoid leading underscores for library prefixes. | ✅ |

--- a/tool/gen_docs.dart
+++ b/tool/gen_docs.dart
@@ -90,14 +90,8 @@ String _createRuleTable(
       final ruleMeta =
           lintMeta.firstWhereOrNull((meta) => meta['name'] == rule);
 
-      if (ruleMeta == null) {
-        print('rules.json data for rule \'$rule\' not found.');
-        print('Update lib/rules.json from '
-            'https://raw.githubusercontent.com/dart-lang/site-www/main/src/_data/linter_rules.json.');
-        exit(1);
-      }
-      final description = ruleMeta['description'] as String?;
-      final hasFix = ruleMeta['fixStatus'] == 'hasFix';
+      final description = ruleMeta?['description'] as String? ?? '';
+      final hasFix = ruleMeta?['fixStatus'] == 'hasFix';
       final fixDesc = hasFix ? '✅' : '';
 
       return '| [`$rule`](https://dart.dev/lints/$rule) | $description | $fixDesc |';

--- a/tool/rules.json
+++ b/tool/rules.json
@@ -27,7 +27,7 @@
   {
     "name": "avoid_returning_null_for_future",
     "description": "Avoid returning null for Future.",
-    "fixStatus": "hasFix"
+    "fixStatus": "noFix"
   },
   {
     "name": "avoid_slow_async_io",
@@ -72,7 +72,7 @@
   {
     "name": "comment_references",
     "description": "Only reference in scope identifiers in doc comments.",
-    "fixStatus": "noFix"
+    "fixStatus": "hasFix"
   },
   {
     "name": "control_flow_in_finally",
@@ -82,7 +82,7 @@
   {
     "name": "deprecated_member_use_from_same_package",
     "description": "Avoid using deprecated elements from within the package in which they are declared.",
-    "fixStatus": "needsFix"
+    "fixStatus": "hasFix"
   },
   {
     "name": "diagnostic_describe_all_properties",
@@ -135,6 +135,11 @@
     "fixStatus": "noFix"
   },
   {
+    "name": "missing_code_block_language_in_doc_comment",
+    "description": "A code block is missing a specified language.",
+    "fixStatus": "needsEvaluation"
+  },
+  {
     "name": "no_adjacent_strings_in_list",
     "description": "Don't use adjacent strings in list.",
     "fixStatus": "needsFix"
@@ -178,6 +183,11 @@
     "name": "throw_in_finally",
     "description": "Avoid `throw` in finally block.",
     "fixStatus": "noFix"
+  },
+  {
+    "name": "unintended_html_in_doc_comment",
+    "description": "Use of angle brackets in a doc comment is treated as HTML by Markdown.",
+    "fixStatus": "needsEvaluation"
   },
   {
     "name": "unnecessary_statements",
@@ -247,7 +257,7 @@
   {
     "name": "always_require_non_null_named_parameters",
     "description": "Specify `@required` on named parameters without defaults.",
-    "fixStatus": "hasFix"
+    "fixStatus": "noFix"
   },
   {
     "name": "always_specify_types",
@@ -522,7 +532,7 @@
   {
     "name": "flutter_style_todos",
     "description": "Use Flutter TODO format: // TODO(username): message, https://URL-to-issue.",
-    "fixStatus": "noFix"
+    "fixStatus": "hasFix"
   },
   {
     "name": "implementation_imports",
@@ -871,7 +881,7 @@
   },
   {
     "name": "require_trailing_commas",
-    "description": "Use trailing commas for all function calls and declarations.",
+    "description": "Use trailing commas for all parameter lists and argument lists.",
     "fixStatus": "hasFix"
   },
   {
@@ -982,6 +992,11 @@
   {
     "name": "unnecessary_library_directive",
     "description": "Avoid library directives unless they have documentation comments or annotations.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "unnecessary_library_name",
+    "description": "Don't have a library name in a `library` declaration.",
     "fixStatus": "hasFix"
   },
   {


### PR DESCRIPTION
- remove the 'library_names' lint

We didn't have a specific issue where we discussed this, but it's ~implicit in https://github.com/dart-lang/lints/issues/181 - adding `unnecessary_library_name`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
