### PR TITLE
add unnecessary_library_name to recommended

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [3.1, stable, beta]
+        sdk: [3.4, stable, beta]
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## 5.0.0-wip
 
 - `recommended`:
-  - added `unnecessary_library_name` (https://github.com/dart-lang/lints/issues/181)
+  - added [unnecessary_library_name] (https://github.com/dart-lang/lints/issues/181)
 - Updated the SDK lower-bound to 3.4.
+
+[unnecessary_library_name]: https://dart.dev/lints/unnecessary_library_name
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.0-wip
+
+- `recommended`:
+  - added `unnecessary_library_name` (https://github.com/dart-lang/lints/issues/181)
+- Updated the SDK lower-bound to 3.4.
+
 ## 4.0.0
 
 - `core`:

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -54,6 +54,7 @@ linter:
     - unnecessary_constructor_name
     - unnecessary_getters_setters
     - unnecessary_late
+    - unnecessary_library_name
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lints
-version: 4.0.0
+version: 5.0.0-wip
 description: >
   Official Dart lint rules. Defines the 'core' and 'recommended' set of lints
   suggested by the Dart team.
@@ -10,7 +10,7 @@ topics:
   - lints
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.4.0
 
 # NOTE: Code is not allowed in this package - do not add dependencies.
 # dependencies:

--- a/rules.md
+++ b/rules.md
@@ -24,20 +24,20 @@
 | [`no_duplicate_case_values`](https://dart.dev/lints/no_duplicate_case_values) | Don't use more than one case with same value. | ✅ |
 | [`no_wildcard_variable_uses`](https://dart.dev/lints/no_wildcard_variable_uses) | Don't use wildcard parameters or variables. |  |
 | [`non_constant_identifier_names`](https://dart.dev/lints/non_constant_identifier_names) | Name non-constant identifiers using lowerCamelCase. | ✅ |
-| [`null_check_on_nullable_type_parameter`](https://dart.dev/lints/null_check_on_nullable_type_parameter) | Don't use null check on a potentially nullable type parameter. | ✅ |
+| [`null_check_on_nullable_type_parameter`](https://dart.dev/lints/null_check_on_nullable_type_parameter) | Don't use `null` check on a potentially nullable type parameter. | ✅ |
 | [`prefer_generic_function_type_aliases`](https://dart.dev/lints/prefer_generic_function_type_aliases) | Prefer generic function type aliases. | ✅ |
-| [`prefer_is_empty`](https://dart.dev/lints/prefer_is_empty) | Use `isEmpty` for Iterables and Maps. | ✅ |
-| [`prefer_is_not_empty`](https://dart.dev/lints/prefer_is_not_empty) | Use `isNotEmpty` for Iterables and Maps. | ✅ |
-| [`prefer_iterable_whereType`](https://dart.dev/lints/prefer_iterable_whereType) | Prefer to use whereType on iterable. | ✅ |
+| [`prefer_is_empty`](https://dart.dev/lints/prefer_is_empty) | Use `isEmpty` for `Iterable`s and `Map`s. | ✅ |
+| [`prefer_is_not_empty`](https://dart.dev/lints/prefer_is_not_empty) | Use `isNotEmpty` for `Iterable`s and `Map`s. | ✅ |
+| [`prefer_iterable_whereType`](https://dart.dev/lints/prefer_iterable_whereType) | Prefer to use `whereType` on iterable. | ✅ |
 | [`prefer_typing_uninitialized_variables`](https://dart.dev/lints/prefer_typing_uninitialized_variables) | Prefer typing uninitialized variables and fields. | ✅ |
-| [`provide_deprecation_message`](https://dart.dev/lints/provide_deprecation_message) | Provide a deprecation message, via @Deprecated("message"). |  |
+| [`provide_deprecation_message`](https://dart.dev/lints/provide_deprecation_message) | Provide a deprecation message, via `@Deprecated("message")`. |  |
 | [`secure_pubspec_urls`](https://dart.dev/lints/secure_pubspec_urls) | Use secure urls in `pubspec.yaml`. |  |
 | [`type_literal_in_constant_pattern`](https://dart.dev/lints/type_literal_in_constant_pattern) | Don't use constant patterns with type literals. | ✅ |
 | [`unnecessary_overrides`](https://dart.dev/lints/unnecessary_overrides) | Don't override a method to do a super method invocation with the same parameters. | ✅ |
 | [`unrelated_type_equality_checks`](https://dart.dev/lints/unrelated_type_equality_checks) | Equality operator `==` invocation with references of unrelated types. |  |
 | [`use_string_in_part_of_directives`](https://dart.dev/lints/use_string_in_part_of_directives) | Use string in part of directives. | ✅ |
 | [`valid_regexps`](https://dart.dev/lints/valid_regexps) | Use valid regular expression syntax. |  |
-| [`void_checks`](https://dart.dev/lints/void_checks) | Don't assign to void. |  |
+| [`void_checks`](https://dart.dev/lints/void_checks) | Don't assign to `void`. |  |
 <!-- core -->
 
 ### Recommended lint rules
@@ -47,14 +47,14 @@
 | :--------- | :---------- | ------- |
 | [`annotate_overrides`](https://dart.dev/lints/annotate_overrides) | Annotate overridden members. | ✅ |
 | [`avoid_function_literals_in_foreach_calls`](https://dart.dev/lints/avoid_function_literals_in_foreach_calls) | Avoid using `forEach` with a function literal. | ✅ |
-| [`avoid_init_to_null`](https://dart.dev/lints/avoid_init_to_null) | Don't explicitly initialize variables to null. | ✅ |
-| [`avoid_null_checks_in_equality_operators`](https://dart.dev/lints/avoid_null_checks_in_equality_operators) | Don't check for null in custom == operators. | ✅ |
+| [`avoid_init_to_null`](https://dart.dev/lints/avoid_init_to_null) | Don't explicitly initialize variables to `null`. | ✅ |
+| [`avoid_null_checks_in_equality_operators`](https://dart.dev/lints/avoid_null_checks_in_equality_operators) | Don't check for `null` in custom `==` operators. | ✅ |
 | [`avoid_renaming_method_parameters`](https://dart.dev/lints/avoid_renaming_method_parameters) | Don't rename parameters of overridden methods. | ✅ |
 | [`avoid_return_types_on_setters`](https://dart.dev/lints/avoid_return_types_on_setters) | Avoid return types on setters. | ✅ |
-| [`avoid_returning_null_for_void`](https://dart.dev/lints/avoid_returning_null_for_void) | Avoid returning null for void. | ✅ |
+| [`avoid_returning_null_for_void`](https://dart.dev/lints/avoid_returning_null_for_void) | Avoid returning `null` for `void`. | ✅ |
 | [`avoid_single_cascade_in_expression_statements`](https://dart.dev/lints/avoid_single_cascade_in_expression_statements) | Avoid single cascade in expression statements. | ✅ |
 | [`constant_identifier_names`](https://dart.dev/lints/constant_identifier_names) | Prefer using lowerCamelCase for constant names. | ✅ |
-| [`control_flow_in_finally`](https://dart.dev/lints/control_flow_in_finally) | Avoid control flow in finally blocks. |  |
+| [`control_flow_in_finally`](https://dart.dev/lints/control_flow_in_finally) | Avoid control flow in `finally` blocks. |  |
 | [`empty_constructor_bodies`](https://dart.dev/lints/empty_constructor_bodies) | Use `;` instead of `{}` for empty constructor bodies. | ✅ |
 | [`empty_statements`](https://dart.dev/lints/empty_statements) | Avoid empty statements. | ✅ |
 | [`exhaustive_cases`](https://dart.dev/lints/exhaustive_cases) | Define case clauses for all constants in enum-like classes. | ✅ |
@@ -68,34 +68,35 @@
 | [`package_names`](https://dart.dev/lints/package_names) | Use `lowercase_with_underscores` for package names. |  |
 | [`prefer_adjacent_string_concatenation`](https://dart.dev/lints/prefer_adjacent_string_concatenation) | Use adjacent strings to concatenate string literals. | ✅ |
 | [`prefer_collection_literals`](https://dart.dev/lints/prefer_collection_literals) | Use collection literals when possible. | ✅ |
-| [`prefer_conditional_assignment`](https://dart.dev/lints/prefer_conditional_assignment) | Prefer using `??=` over testing for null. | ✅ |
+| [`prefer_conditional_assignment`](https://dart.dev/lints/prefer_conditional_assignment) | Prefer using `??=` over testing for `null`. | ✅ |
 | [`prefer_contains`](https://dart.dev/lints/prefer_contains) | Use contains for `List` and `String` instances. | ✅ |
-| [`prefer_final_fields`](https://dart.dev/lints/prefer_final_fields) | Private field could be final. | ✅ |
-| [`prefer_for_elements_to_map_fromIterable`](https://dart.dev/lints/prefer_for_elements_to_map_fromIterable) | Prefer 'for' elements when building maps from iterables. | ✅ |
+| [`prefer_final_fields`](https://dart.dev/lints/prefer_final_fields) | Private field could be `final`. | ✅ |
+| [`prefer_for_elements_to_map_fromIterable`](https://dart.dev/lints/prefer_for_elements_to_map_fromIterable) | Prefer `for` elements when building maps from iterables. | ✅ |
 | [`prefer_function_declarations_over_variables`](https://dart.dev/lints/prefer_function_declarations_over_variables) | Use a function declaration to bind a function to a name. | ✅ |
-| [`prefer_if_null_operators`](https://dart.dev/lints/prefer_if_null_operators) | Prefer using if null operators. | ✅ |
+| [`prefer_if_null_operators`](https://dart.dev/lints/prefer_if_null_operators) | Prefer using `??` operators. | ✅ |
 | [`prefer_initializing_formals`](https://dart.dev/lints/prefer_initializing_formals) | Use initializing formals when possible. | ✅ |
 | [`prefer_inlined_adds`](https://dart.dev/lints/prefer_inlined_adds) | Inline list item declarations where possible. | ✅ |
 | [`prefer_interpolation_to_compose_strings`](https://dart.dev/lints/prefer_interpolation_to_compose_strings) | Use interpolation to compose strings and values. | ✅ |
 | [`prefer_is_not_operator`](https://dart.dev/lints/prefer_is_not_operator) | Prefer is! operator. | ✅ |
-| [`prefer_null_aware_operators`](https://dart.dev/lints/prefer_null_aware_operators) | Prefer using null aware operators. | ✅ |
+| [`prefer_null_aware_operators`](https://dart.dev/lints/prefer_null_aware_operators) | Prefer using `null`-aware operators. | ✅ |
 | [`prefer_spread_collections`](https://dart.dev/lints/prefer_spread_collections) | Use spread collections when possible. | ✅ |
 | [`recursive_getters`](https://dart.dev/lints/recursive_getters) | Property getter recursively returns itself. |  |
-| [`slash_for_doc_comments`](https://dart.dev/lints/slash_for_doc_comments) | Prefer using /// for doc comments. | ✅ |
+| [`slash_for_doc_comments`](https://dart.dev/lints/slash_for_doc_comments) | Prefer using `///` for doc comments. | ✅ |
 | [`type_init_formals`](https://dart.dev/lints/type_init_formals) | Don't type annotate initializing formals. | ✅ |
 | [`unnecessary_brace_in_string_interps`](https://dart.dev/lints/unnecessary_brace_in_string_interps) | Avoid using braces in interpolation when not needed. | ✅ |
-| [`unnecessary_const`](https://dart.dev/lints/unnecessary_const) | Avoid const keyword. | ✅ |
+| [`unnecessary_const`](https://dart.dev/lints/unnecessary_const) | Avoid `const` keyword. | ✅ |
 | [`unnecessary_constructor_name`](https://dart.dev/lints/unnecessary_constructor_name) | Unnecessary `.new` constructor name. | ✅ |
 | [`unnecessary_getters_setters`](https://dart.dev/lints/unnecessary_getters_setters) | Avoid wrapping fields in getters and setters just to be "safe". | ✅ |
 | [`unnecessary_late`](https://dart.dev/lints/unnecessary_late) | Don't specify the `late` modifier when it is not needed. | ✅ |
+| [`unnecessary_library_name`](https://dart.dev/lints/unnecessary_library_name) | Don't have a library name in a `library` declaration. | ✅ |
 | [`unnecessary_new`](https://dart.dev/lints/unnecessary_new) | Unnecessary new keyword. | ✅ |
-| [`unnecessary_null_aware_assignments`](https://dart.dev/lints/unnecessary_null_aware_assignments) | Avoid null in null-aware assignment. | ✅ |
-| [`unnecessary_null_in_if_null_operators`](https://dart.dev/lints/unnecessary_null_in_if_null_operators) | Avoid using `null` in `if null` operators. | ✅ |
+| [`unnecessary_null_aware_assignments`](https://dart.dev/lints/unnecessary_null_aware_assignments) | Avoid `null` in `null`-aware assignment. | ✅ |
+| [`unnecessary_null_in_if_null_operators`](https://dart.dev/lints/unnecessary_null_in_if_null_operators) | Avoid using `null` in `??` operators. | ✅ |
 | [`unnecessary_nullable_for_final_variable_declarations`](https://dart.dev/lints/unnecessary_nullable_for_final_variable_declarations) | Use a non-nullable type for a final variable initialized with a non-nullable value. | ✅ |
 | [`unnecessary_string_escapes`](https://dart.dev/lints/unnecessary_string_escapes) | Remove unnecessary backslashes in strings. | ✅ |
 | [`unnecessary_string_interpolations`](https://dart.dev/lints/unnecessary_string_interpolations) | Unnecessary string interpolation. | ✅ |
 | [`unnecessary_this`](https://dart.dev/lints/unnecessary_this) | Don't access members with `this` unless avoiding shadowing. | ✅ |
-| [`unnecessary_to_list_in_spreads`](https://dart.dev/lints/unnecessary_to_list_in_spreads) | Unnecessary toList() in spreads. | ✅ |
+| [`unnecessary_to_list_in_spreads`](https://dart.dev/lints/unnecessary_to_list_in_spreads) | Unnecessary `toList()` in spreads. | ✅ |
 | [`use_function_type_syntax_for_parameters`](https://dart.dev/lints/use_function_type_syntax_for_parameters) | Use generic function type syntax for parameters. | ✅ |
 | [`use_rethrow_when_possible`](https://dart.dev/lints/use_rethrow_when_possible) | Use rethrow to rethrow a caught exception. | ✅ |
 | [`use_super_parameters`](https://dart.dev/lints/use_super_parameters) | Use super-initializer parameters where possible. | ✅ |

--- a/tool/rules.json
+++ b/tool/rules.json
@@ -1,245 +1,5 @@
 [
   {
-    "name": "always_use_package_imports",
-    "description": "Avoid relative imports for files in `lib/`.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "avoid_dynamic_calls",
-    "description": "Avoid method calls or property accesses on a \"dynamic\" target.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "avoid_empty_else",
-    "description": "Avoid empty statements in else clauses.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "avoid_print",
-    "description": "Avoid `print` calls in production code.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "avoid_relative_lib_imports",
-    "description": "Avoid relative imports for files in `lib/`.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "avoid_returning_null_for_future",
-    "description": "Avoid returning null for Future.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "avoid_slow_async_io",
-    "description": "Avoid slow async `dart:io` methods.",
-    "fixStatus": "needsFix"
-  },
-  {
-    "name": "avoid_type_to_string",
-    "description": "Avoid <Type>.toString() in production code since results may be minified.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "avoid_types_as_parameter_names",
-    "description": "Avoid types as parameter names.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "avoid_unstable_final_fields",
-    "description": "Avoid overriding a final field to return different values if called multiple times.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "avoid_web_libraries_in_flutter",
-    "description": "Avoid using web-only libraries outside Flutter web plugin packages.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "cancel_subscriptions",
-    "description": "Cancel instances of dart.async.StreamSubscription.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "close_sinks",
-    "description": "Close instances of `dart.core.Sink`.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "collection_methods_unrelated_type",
-    "description": "Invocation of various collection methods with arguments of unrelated types.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "comment_references",
-    "description": "Only reference in scope identifiers in doc comments.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "control_flow_in_finally",
-    "description": "Avoid control flow in finally blocks.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "deprecated_member_use_from_same_package",
-    "description": "Avoid using deprecated elements from within the package in which they are declared.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "diagnostic_describe_all_properties",
-    "description": "DO reference all public properties in debug methods.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "discarded_futures",
-    "description": "Don't invoke asynchronous functions in non-async blocks.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "empty_statements",
-    "description": "Avoid empty statements.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "hash_and_equals",
-    "description": "Always override `hashCode` if overriding `==`.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "implicit_reopen",
-    "description": "Don't implicitly reopen classes.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "invalid_case_patterns",
-    "description": "Use case expressions that are valid in Dart 3.0.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "invariant_booleans",
-    "description": "Conditions should not unconditionally evaluate to `true` or to `false`.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "iterable_contains_unrelated_type",
-    "description": "Invocation of Iterable<E>.contains with references of unrelated types.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "list_remove_unrelated_type",
-    "description": "Invocation of `remove` with references of unrelated types.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "literal_only_boolean_expressions",
-    "description": "Boolean expression composed only with literals.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "missing_code_block_language_in_doc_comment",
-    "description": "A code block is missing a specified language.",
-    "fixStatus": "needsEvaluation"
-  },
-  {
-    "name": "no_adjacent_strings_in_list",
-    "description": "Don't use adjacent strings in list.",
-    "fixStatus": "needsFix"
-  },
-  {
-    "name": "no_duplicate_case_values",
-    "description": "Don't use more than one case with same value.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "no_logic_in_create_state",
-    "description": "Don't put any logic in createState.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "no_self_assignments",
-    "description": "Don't assign a variable to itself.",
-    "fixStatus": "needsEvaluation"
-  },
-  {
-    "name": "no_wildcard_variable_uses",
-    "description": "Don't use wildcard parameters or variables.",
-    "fixStatus": "needsEvaluation"
-  },
-  {
-    "name": "prefer_relative_imports",
-    "description": "Prefer relative imports for files in `lib/`.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "prefer_void_to_null",
-    "description": "Don't use the Null type, unless you are positive that you don't want void.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "test_types_in_equals",
-    "description": "Test type arguments in operator ==(Object other).",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "throw_in_finally",
-    "description": "Avoid `throw` in finally block.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "unintended_html_in_doc_comment",
-    "description": "Use of angle brackets in a doc comment is treated as HTML by Markdown.",
-    "fixStatus": "needsEvaluation"
-  },
-  {
-    "name": "unnecessary_statements",
-    "description": "Avoid using unnecessary statements.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "unrelated_type_equality_checks",
-    "description": "Equality operator `==` invocation with references of unrelated types.",
-    "fixStatus": "unregistered"
-  },
-  {
-    "name": "unsafe_html",
-    "description": "Avoid unsafe HTML APIs.",
-    "fixStatus": "unregistered"
-  },
-  {
-    "name": "use_build_context_synchronously",
-    "description": "Do not use BuildContexts across async gaps.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "use_key_in_widget_constructors",
-    "description": "Use key in widget constructors.",
-    "fixStatus": "hasFix"
-  },
-  {
-    "name": "valid_regexps",
-    "description": "Use valid regular expression syntax.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "depend_on_referenced_packages",
-    "description": "Depend on referenced packages.",
-    "fixStatus": "needsFix"
-  },
-  {
-    "name": "package_names",
-    "description": "Use `lowercase_with_underscores` for package names.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "secure_pubspec_urls",
-    "description": "Use secure urls in `pubspec.yaml`.",
-    "fixStatus": "noFix"
-  },
-  {
-    "name": "sort_pub_dependencies",
-    "description": "Sort pub dependencies alphabetically.",
-    "fixStatus": "needsFix"
-  },
-  {
     "name": "always_declare_return_types",
     "description": "Declare method return types.",
     "fixStatus": "hasFix"
@@ -265,6 +25,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "always_use_package_imports",
+    "description": "Avoid relative imports for files in `lib/`.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "annotate_overrides",
     "description": "Annotate overridden members.",
     "fixStatus": "hasFix"
@@ -276,7 +41,7 @@
   },
   {
     "name": "avoid_annotating_with_dynamic",
-    "description": "Avoid annotating with dynamic when not required.",
+    "description": "Avoid annotating with `dynamic` when not required.",
     "fixStatus": "hasFix"
   },
   {
@@ -286,7 +51,7 @@
   },
   {
     "name": "avoid_bool_literals_in_conditional_expressions",
-    "description": "Avoid bool literals in conditional expressions.",
+    "description": "Avoid `bool` literals in conditional expressions.",
     "fixStatus": "needsFix"
   },
   {
@@ -296,7 +61,7 @@
   },
   {
     "name": "avoid_catching_errors",
-    "description": "Don't explicitly catch Error or types that implement it.",
+    "description": "Don't explicitly catch `Error` or types that implement it.",
     "fixStatus": "unregistered"
   },
   {
@@ -306,8 +71,18 @@
   },
   {
     "name": "avoid_double_and_int_checks",
-    "description": "Avoid double and int checks.",
+    "description": "Avoid `double` and `int` checks.",
     "fixStatus": "needsFix"
+  },
+  {
+    "name": "avoid_dynamic_calls",
+    "description": "Avoid method calls or property accesses on a `dynamic` target.",
+    "fixStatus": "noFix"
+  },
+  {
+    "name": "avoid_empty_else",
+    "description": "Avoid empty statements in else clauses.",
+    "fixStatus": "hasFix"
   },
   {
     "name": "avoid_equals_and_hash_code_on_mutable_classes",
@@ -326,7 +101,7 @@
   },
   {
     "name": "avoid_final_parameters",
-    "description": "Avoid final for parameter declarations.",
+    "description": "Avoid `final` for parameter declarations.",
     "fixStatus": "needsFix"
   },
   {
@@ -341,7 +116,7 @@
   },
   {
     "name": "avoid_init_to_null",
-    "description": "Don't explicitly initialize variables to null.",
+    "description": "Don't explicitly initialize variables to `null`.",
     "fixStatus": "hasFix"
   },
   {
@@ -356,13 +131,18 @@
   },
   {
     "name": "avoid_null_checks_in_equality_operators",
-    "description": "Don't check for null in custom == operators.",
+    "description": "Don't check for `null` in custom `==` operators.",
     "fixStatus": "hasFix"
   },
   {
     "name": "avoid_positional_boolean_parameters",
     "description": "Avoid positional boolean parameters.",
     "fixStatus": "noFix"
+  },
+  {
+    "name": "avoid_print",
+    "description": "Avoid `print` calls in production code.",
+    "fixStatus": "hasFix"
   },
   {
     "name": "avoid_private_typedef_functions",
@@ -372,6 +152,11 @@
   {
     "name": "avoid_redundant_argument_values",
     "description": "Avoid redundant argument values.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "avoid_relative_lib_imports",
+    "description": "Avoid relative imports for files in `lib/`.",
     "fixStatus": "hasFix"
   },
   {
@@ -390,8 +175,13 @@
     "fixStatus": "noFix"
   },
   {
+    "name": "avoid_returning_null_for_future",
+    "description": "Avoid returning null for Future.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "avoid_returning_null_for_void",
-    "description": "Avoid returning null for void.",
+    "description": "Avoid returning `null` for `void`.",
     "fixStatus": "hasFix"
   },
   {
@@ -415,6 +205,21 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "avoid_slow_async_io",
+    "description": "Avoid slow asynchronous `dart:io` methods.",
+    "fixStatus": "needsFix"
+  },
+  {
+    "name": "avoid_type_to_string",
+    "description": "Avoid <Type>.toString() in production code since results may be minified.",
+    "fixStatus": "noFix"
+  },
+  {
+    "name": "avoid_types_as_parameter_names",
+    "description": "Avoid types as parameter names.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "avoid_types_on_closure_parameters",
     "description": "Avoid annotating types for function expression parameters.",
     "fixStatus": "hasFix"
@@ -425,14 +230,24 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "avoid_unstable_final_fields",
+    "description": "Avoid overriding a final field to return different values if called multiple times.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "avoid_unused_constructor_parameters",
     "description": "Avoid defining unused parameters in constructors.",
     "fixStatus": "hasFix"
   },
   {
     "name": "avoid_void_async",
-    "description": "Avoid async functions that return void.",
+    "description": "Avoid `async` functions that return `void`.",
     "fixStatus": "hasFix"
+  },
+  {
+    "name": "avoid_web_libraries_in_flutter",
+    "description": "Avoid using web-only libraries outside Flutter web plugin packages.",
+    "fixStatus": "noFix"
   },
   {
     "name": "await_only_futures",
@@ -450,6 +265,11 @@
     "fixStatus": "noFix"
   },
   {
+    "name": "cancel_subscriptions",
+    "description": "Cancel instances of `dart:async` `StreamSubscription`.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "cascade_invocations",
     "description": "Cascade consecutive method invocations on the same reference.",
     "fixStatus": "hasFix"
@@ -460,8 +280,23 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "close_sinks",
+    "description": "Close instances of `dart:core` `Sink`.",
+    "fixStatus": "noFix"
+  },
+  {
+    "name": "collection_methods_unrelated_type",
+    "description": "Invocation of various collection methods with arguments of unrelated types.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "combinators_ordering",
     "description": "Sort combinator names alphabetically.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "comment_references",
+    "description": "Only reference in scope identifiers in doc comments.",
     "fixStatus": "hasFix"
   },
   {
@@ -475,6 +310,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "control_flow_in_finally",
+    "description": "Avoid control flow in `finally` blocks.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "curly_braces_in_flow_control_structures",
     "description": "DO use curly braces for all flow control structures.",
     "fixStatus": "hasFix"
@@ -485,9 +325,24 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "depend_on_referenced_packages",
+    "description": "Depend on referenced packages.",
+    "fixStatus": "needsFix"
+  },
+  {
     "name": "deprecated_consistency",
     "description": "Missing deprecated annotation.",
     "fixStatus": "needsFix"
+  },
+  {
+    "name": "deprecated_member_use_from_same_package",
+    "description": "Avoid using deprecated elements from within the package in which they are declared.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "diagnostic_describe_all_properties",
+    "description": "DO reference all public properties in debug methods.",
+    "fixStatus": "hasFix"
   },
   {
     "name": "directives_ordering",
@@ -495,9 +350,19 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "discarded_futures",
+    "description": "Don't invoke asynchronous functions in non-`async` blocks.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "do_not_use_environment",
     "description": "Do not use environment declared variables.",
     "fixStatus": "noFix"
+  },
+  {
+    "name": "document_ignores",
+    "description": "Document ignore comments.",
+    "fixStatus": "needsFix"
   },
   {
     "name": "empty_catches",
@@ -507,6 +372,11 @@
   {
     "name": "empty_constructor_bodies",
     "description": "Use `;` instead of `{}` for empty constructor bodies.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "empty_statements",
+    "description": "Avoid empty statements.",
     "fixStatus": "hasFix"
   },
   {
@@ -535,6 +405,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "hash_and_equals",
+    "description": "Always override `hashCode` if overriding `==`.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "implementation_imports",
     "description": "Don't import implementation files from another package.",
     "fixStatus": "noFix"
@@ -543,6 +418,31 @@
     "name": "implicit_call_tearoffs",
     "description": "Explicitly tear-off `call` methods when using an object as a Function.",
     "fixStatus": "hasFix"
+  },
+  {
+    "name": "implicit_reopen",
+    "description": "Don't implicitly reopen classes.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "invalid_case_patterns",
+    "description": "Use case expressions that are valid in Dart 3.0.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "invalid_runtime_check_with_js_interop_types",
+    "description": "Avoid runtime type tests with JS interop types where the result may not\n    be platform-consistent.",
+    "fixStatus": "needsFix"
+  },
+  {
+    "name": "invariant_booleans",
+    "description": "Conditions should not unconditionally evaluate to `true` or to `false`.",
+    "fixStatus": "noFix"
+  },
+  {
+    "name": "iterable_contains_unrelated_type",
+    "description": "Invocation of `Iterable<E>.contains` with references of unrelated types.",
+    "fixStatus": "noFix"
   },
   {
     "name": "join_return_with_assignment",
@@ -580,9 +480,24 @@
     "fixStatus": "noFix"
   },
   {
+    "name": "list_remove_unrelated_type",
+    "description": "Invocation of `remove` with references of unrelated types.",
+    "fixStatus": "noFix"
+  },
+  {
+    "name": "literal_only_boolean_expressions",
+    "description": "Boolean expression composed only with literals.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "matching_super_parameters",
     "description": "Use matching super parameter names.",
     "fixStatus": "needsFix"
+  },
+  {
+    "name": "missing_code_block_language_in_doc_comment",
+    "description": "A code block is missing a specified language.",
+    "fixStatus": "needsEvaluation"
   },
   {
     "name": "missing_whitespace_between_adjacent_strings",
@@ -590,9 +505,19 @@
     "fixStatus": "needsFix"
   },
   {
+    "name": "no_adjacent_strings_in_list",
+    "description": "Don't use adjacent strings in list.",
+    "fixStatus": "needsFix"
+  },
+  {
     "name": "no_default_cases",
     "description": "No default cases.",
     "fixStatus": "needsFix"
+  },
+  {
+    "name": "no_duplicate_case_values",
+    "description": "Don't use more than one case with same value.",
+    "fixStatus": "hasFix"
   },
   {
     "name": "no_leading_underscores_for_library_prefixes",
@@ -610,9 +535,24 @@
     "fixStatus": "hasFix"
   },
   {
-    "name": "no_runtimeType_toString",
-    "description": "Avoid calling toString() on runtimeType.",
+    "name": "no_logic_in_create_state",
+    "description": "Don't put any logic in createState.",
     "fixStatus": "noFix"
+  },
+  {
+    "name": "no_runtimeType_toString",
+    "description": "Avoid calling `toString()` on `runtimeType`.",
+    "fixStatus": "noFix"
+  },
+  {
+    "name": "no_self_assignments",
+    "description": "Don't assign a variable to itself.",
+    "fixStatus": "needsEvaluation"
+  },
+  {
+    "name": "no_wildcard_variable_uses",
+    "description": "Don't use wildcard parameters or variables.",
+    "fixStatus": "needsEvaluation"
   },
   {
     "name": "non_constant_identifier_names",
@@ -626,7 +566,7 @@
   },
   {
     "name": "null_check_on_nullable_type_parameter",
-    "description": "Don't use null check on a potentially nullable type parameter.",
+    "description": "Don't use `null` check on a potentially nullable type parameter.",
     "fixStatus": "hasFix"
   },
   {
@@ -657,6 +597,11 @@
   {
     "name": "package_api_docs",
     "description": "Provide doc comments for all public APIs.",
+    "fixStatus": "noFix"
+  },
+  {
+    "name": "package_names",
+    "description": "Use `lowercase_with_underscores` for package names.",
     "fixStatus": "noFix"
   },
   {
@@ -696,22 +641,22 @@
   },
   {
     "name": "prefer_conditional_assignment",
-    "description": "Prefer using `??=` over testing for null.",
+    "description": "Prefer using `??=` over testing for `null`.",
     "fixStatus": "hasFix"
   },
   {
     "name": "prefer_const_constructors",
-    "description": "Prefer const with constant constructors.",
+    "description": "Prefer `const` with constant constructors.",
     "fixStatus": "hasFix"
   },
   {
     "name": "prefer_const_constructors_in_immutables",
-    "description": "Prefer declaring const constructors on `@immutable` classes.",
+    "description": "Prefer declaring `const` constructors on `@immutable` classes.",
     "fixStatus": "hasFix"
   },
   {
     "name": "prefer_const_declarations",
-    "description": "Prefer const over final for declarations.",
+    "description": "Prefer `const` over `final` for declarations.",
     "fixStatus": "hasFix"
   },
   {
@@ -746,7 +691,7 @@
   },
   {
     "name": "prefer_final_fields",
-    "description": "Private field could be final.",
+    "description": "Private field could be `final`.",
     "fixStatus": "hasFix"
   },
   {
@@ -766,7 +711,7 @@
   },
   {
     "name": "prefer_for_elements_to_map_fromIterable",
-    "description": "Prefer 'for' elements when building maps from iterables.",
+    "description": "Prefer `for` elements when building maps from iterables.",
     "fixStatus": "hasFix"
   },
   {
@@ -791,7 +736,7 @@
   },
   {
     "name": "prefer_if_null_operators",
-    "description": "Prefer using if null operators.",
+    "description": "Prefer using `??` operators.",
     "fixStatus": "hasFix"
   },
   {
@@ -816,12 +761,12 @@
   },
   {
     "name": "prefer_is_empty",
-    "description": "Use `isEmpty` for Iterables and Maps.",
+    "description": "Use `isEmpty` for `Iterable`s and `Map`s.",
     "fixStatus": "hasFix"
   },
   {
     "name": "prefer_is_not_empty",
-    "description": "Use `isNotEmpty` for Iterables and Maps.",
+    "description": "Use `isNotEmpty` for `Iterable`s and `Map`s.",
     "fixStatus": "hasFix"
   },
   {
@@ -831,7 +776,7 @@
   },
   {
     "name": "prefer_iterable_whereType",
-    "description": "Prefer to use whereType on iterable.",
+    "description": "Prefer to use `whereType` on iterable.",
     "fixStatus": "hasFix"
   },
   {
@@ -841,12 +786,17 @@
   },
   {
     "name": "prefer_null_aware_method_calls",
-    "description": "Prefer null aware method calls.",
+    "description": "Prefer `null`-aware method calls.",
     "fixStatus": "needsFix"
   },
   {
     "name": "prefer_null_aware_operators",
-    "description": "Prefer using null aware operators.",
+    "description": "Prefer using `null`-aware operators.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "prefer_relative_imports",
+    "description": "Prefer relative imports for files in `lib/`.",
     "fixStatus": "hasFix"
   },
   {
@@ -865,8 +815,13 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "prefer_void_to_null",
+    "description": "Don't use the Null type, unless you are positive that you don't want void.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "provide_deprecation_message",
-    "description": "Provide a deprecation message, via @Deprecated(\"message\").",
+    "description": "Provide a deprecation message, via `@Deprecated(\"message\")`.",
     "fixStatus": "noFix"
   },
   {
@@ -885,8 +840,13 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "secure_pubspec_urls",
+    "description": "Use secure urls in `pubspec.yaml`.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "sized_box_for_whitespace",
-    "description": "SizedBox for whitespace.",
+    "description": "`SizedBox` for whitespace.",
     "fixStatus": "hasFix"
   },
   {
@@ -896,7 +856,7 @@
   },
   {
     "name": "slash_for_doc_comments",
-    "description": "Prefer using /// for doc comments.",
+    "description": "Prefer using `///` for doc comments.",
     "fixStatus": "hasFix"
   },
   {
@@ -910,6 +870,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "sort_pub_dependencies",
+    "description": "Sort pub dependencies alphabetically.",
+    "fixStatus": "needsFix"
+  },
+  {
     "name": "sort_unnamed_constructors_first",
     "description": "Sort unnamed constructor declarations first.",
     "fixStatus": "hasFix"
@@ -917,6 +882,16 @@
   {
     "name": "super_goes_last",
     "description": "Place the `super` call last in a constructor initialization list.",
+    "fixStatus": "noFix"
+  },
+  {
+    "name": "test_types_in_equals",
+    "description": "Test type of argument in `operator ==(Object other)`.",
+    "fixStatus": "noFix"
+  },
+  {
+    "name": "throw_in_finally",
+    "description": "Avoid `throw` in `finally` block.",
     "fixStatus": "noFix"
   },
   {
@@ -945,9 +920,14 @@
     "fixStatus": "hasFix"
   },
   {
-    "name": "unnecessary_await_in_return",
-    "description": "Unnecessary await keyword in return.",
+    "name": "unintended_html_in_doc_comment",
+    "description": "Use of angle brackets in a doc comment is treated as HTML by Markdown.",
     "fixStatus": "needsFix"
+  },
+  {
+    "name": "unnecessary_await_in_return",
+    "description": "Unnecessary `await` keyword in return.",
+    "fixStatus": "hasFix"
   },
   {
     "name": "unnecessary_brace_in_string_interps",
@@ -961,7 +941,7 @@
   },
   {
     "name": "unnecessary_const",
-    "description": "Avoid const keyword.",
+    "description": "Avoid `const` keyword.",
     "fixStatus": "hasFix"
   },
   {
@@ -1006,7 +986,7 @@
   },
   {
     "name": "unnecessary_null_aware_assignments",
-    "description": "Avoid null in null-aware assignment.",
+    "description": "Avoid `null` in `null`-aware assignment.",
     "fixStatus": "hasFix"
   },
   {
@@ -1016,12 +996,12 @@
   },
   {
     "name": "unnecessary_null_checks",
-    "description": "Unnecessary null checks.",
+    "description": "Unnecessary `null` checks.",
     "fixStatus": "hasFix"
   },
   {
     "name": "unnecessary_null_in_if_null_operators",
-    "description": "Avoid using `null` in `if null` operators.",
+    "description": "Avoid using `null` in `??` operators.",
     "fixStatus": "hasFix"
   },
   {
@@ -1045,6 +1025,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "unnecessary_statements",
+    "description": "Avoid using unnecessary statements.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "unnecessary_string_escapes",
     "description": "Remove unnecessary backslashes in strings.",
     "fixStatus": "hasFix"
@@ -1061,13 +1046,28 @@
   },
   {
     "name": "unnecessary_to_list_in_spreads",
-    "description": "Unnecessary toList() in spreads.",
+    "description": "Unnecessary `toList()` in spreads.",
     "fixStatus": "hasFix"
   },
   {
     "name": "unreachable_from_main",
     "description": "Unreachable top-level members in executable libraries.",
     "fixStatus": "hasFix"
+  },
+  {
+    "name": "unrelated_type_equality_checks",
+    "description": "Equality operator `==` invocation with references of unrelated types.",
+    "fixStatus": "unregistered"
+  },
+  {
+    "name": "unsafe_html",
+    "description": "Avoid unsafe HTML APIs.",
+    "fixStatus": "unregistered"
+  },
+  {
+    "name": "use_build_context_synchronously",
+    "description": "Do not use `BuildContext` across asynchronous gaps.",
+    "fixStatus": "unregistered"
   },
   {
     "name": "use_colored_box",
@@ -1096,13 +1096,18 @@
   },
   {
     "name": "use_if_null_to_convert_nulls_to_bools",
-    "description": "Use if-null operators to convert nulls to bools.",
+    "description": "Use `??` operators to convert `null`s to `bool`s.",
     "fixStatus": "needsFix"
   },
   {
     "name": "use_is_even_rather_than_modulo",
     "description": "Prefer intValue.isOdd/isEven instead of checking the result of % 2.",
     "fixStatus": "needsFix"
+  },
+  {
+    "name": "use_key_in_widget_constructors",
+    "description": "Use key in widget constructors.",
+    "fixStatus": "hasFix"
   },
   {
     "name": "use_late_for_private_fields_and_variables",
@@ -1112,7 +1117,7 @@
   {
     "name": "use_named_constants",
     "description": "Use predefined named constants.",
-    "fixStatus": "needsFix"
+    "fixStatus": "hasFix"
   },
   {
     "name": "use_raw_strings",
@@ -1155,8 +1160,13 @@
     "fixStatus": "noFix"
   },
   {
+    "name": "valid_regexps",
+    "description": "Use valid regular expression syntax.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "void_checks",
-    "description": "Don't assign to void.",
+    "description": "Don't assign to `void`.",
     "fixStatus": "noFix"
   }
 ]


### PR DESCRIPTION
- add `unnecessary_library_name` to the recommended lint set
- close https://github.com/dart-lang/lints/issues/181
- bump the min sdk to the first stable containing this lint

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
