### PR TITLE
add invalid_runtime_check_with_js_interop_types to the recommended lint set

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [3.4, stable, beta]
+        sdk: [3.5, stable, beta]
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 - `recommended`:
   - added [unnecessary_library_name] (https://github.com/dart-lang/lints/issues/181)
-- Updated the SDK lower-bound to 3.4.
+  - added [invalid_runtime_check_with_js_interop_types] (https://github.com/dart-lang/lints/issues/188)
+- Updated the SDK lower-bound to 3.5.
 
 [unnecessary_library_name]: https://dart.dev/lints/unnecessary_library_name
+[invalid_runtime_check_with_js_interop_types]: https://dart.dev/tools/linter-rules/invalid_runtime_check_with_js_interop_types
 
 ## 4.0.0
 

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -25,6 +25,7 @@ linter:
     - empty_statements
     - exhaustive_cases
     - implementation_imports
+    - invalid_runtime_check_with_js_interop_types
     - library_prefixes
     - library_private_types_in_public_api
     - no_leading_underscores_for_library_prefixes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - lints
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0
 
 # NOTE: Code is not allowed in this package - do not add dependencies.
 # dependencies:

--- a/rules.md
+++ b/rules.md
@@ -59,6 +59,8 @@
 | [`empty_statements`](https://dart.dev/lints/empty_statements) | Avoid empty statements. | ✅ |
 | [`exhaustive_cases`](https://dart.dev/lints/exhaustive_cases) | Define case clauses for all constants in enum-like classes. | ✅ |
 | [`implementation_imports`](https://dart.dev/lints/implementation_imports) | Don't import implementation files from another package. |  |
+| [`invalid_runtime_check_with_js_interop_types`](https://dart.dev/lints/invalid_runtime_check_with_js_interop_types) | Avoid runtime type tests with JS interop types where the result may not
+    be platform-consistent. |  |
 | [`library_prefixes`](https://dart.dev/lints/library_prefixes) | Use `lowercase_with_underscores` when specifying a library prefix. |  |
 | [`library_private_types_in_public_api`](https://dart.dev/lints/library_private_types_in_public_api) | Avoid using private types in public APIs. |  |
 | [`no_leading_underscores_for_library_prefixes`](https://dart.dev/lints/no_leading_underscores_for_library_prefixes) | Avoid leading underscores for library prefixes. | ✅ |

--- a/tool/rules.json
+++ b/tool/rules.json
@@ -296,7 +296,7 @@
   },
   {
     "name": "comment_references",
-    "description": "Only reference in scope identifiers in doc comments.",
+    "description": "Only reference in-scope identifiers in doc comments.",
     "fixStatus": "hasFix"
   },
   {
@@ -531,7 +531,7 @@
   },
   {
     "name": "no_literal_bool_comparisons",
-    "description": "Don't compare booleans to boolean literals.",
+    "description": "Don't compare Boolean expressions to Boolean literals.",
     "fixStatus": "hasFix"
   },
   {
@@ -577,6 +577,11 @@
   {
     "name": "omit_local_variable_types",
     "description": "Omit type annotations for local variables.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "omit_obvious_local_variable_types",
+    "description": "Omit obvious type annotations for local variables.",
     "fixStatus": "hasFix"
   },
   {
@@ -1086,7 +1091,7 @@
   },
   {
     "name": "use_full_hex_values_for_flutter_colors",
-    "description": "Prefer an 8-digit hexadecimal integer(0xFFFFFFFF) to instantiate Color.",
+    "description": "Prefer an 8-digit hexadecimal integer (for example, 0xFFFFFFFF) to instantiate a Color.",
     "fixStatus": "hasFix"
   },
   {
@@ -1158,6 +1163,11 @@
     "name": "use_to_and_as_if_applicable",
     "description": "Start the name of the method with to/_to or as/_as if applicable.",
     "fixStatus": "noFix"
+  },
+  {
+    "name": "use_truncating_division",
+    "description": "Use truncating division.",
+    "fixStatus": "hasFix"
   },
   {
     "name": "valid_regexps",


### PR DESCRIPTION
- add `invalid_runtime_check_with_js_interop_types` to the recommended lint set
- rev the min. sdk to 3.5
- closes https://github.com/dart-lang/lints/issues/188

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
