### PR TITLE
add `unintended_html_in_doc_comment` to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 ## 5.0.0-wip
 
+- `core`:
+  - added [unintended_html_in_doc_comment] (https://github.com/dart-lang/lints/issues/192)
 - `recommended`:
-  - added [unnecessary_library_name] (https://github.com/dart-lang/lints/issues/181)
   - added [invalid_runtime_check_with_js_interop_types] (https://github.com/dart-lang/lints/issues/188)
+  - added [unnecessary_library_name] (https://github.com/dart-lang/lints/issues/181)
   - removed [avoid_null_checks_in_equality_operators] (https://github.com/dart-lang/lints/issues/200)
 - Updated the SDK lower-bound to 3.5.
 
-[unnecessary_library_name]: https://dart.dev/lints/unnecessary_library_name
-[invalid_runtime_check_with_js_interop_types]: https://dart.dev/tools/linter-rules/invalid_runtime_check_with_js_interop_types
 [avoid_null_checks_in_equality_operators]: https://dart.dev/tools/linter-rules/avoid_null_checks_in_equality_operators
+[invalid_runtime_check_with_js_interop_types]: https://dart.dev/tools/linter-rules/invalid_runtime_check_with_js_interop_types
+[unintended_html_in_doc_comment]: https://dart.dev/lints/unnecessary_library_name
+[unnecessary_library_name]: https://dart.dev/lints/unnecessary_library_name
 
 ## 4.0.0
 

--- a/lib/core.yaml
+++ b/lib/core.yaml
@@ -34,6 +34,7 @@ linter:
     - provide_deprecation_message
     - secure_pubspec_urls
     - type_literal_in_constant_pattern
+    - unintended_html_in_doc_comment
     - unnecessary_overrides
     - unrelated_type_equality_checks
     - use_string_in_part_of_directives

--- a/rules.md
+++ b/rules.md
@@ -33,6 +33,7 @@
 | [`provide_deprecation_message`](https://dart.dev/lints/provide_deprecation_message) | Provide a deprecation message, via `@Deprecated("message")`. |  |
 | [`secure_pubspec_urls`](https://dart.dev/lints/secure_pubspec_urls) | Use secure urls in `pubspec.yaml`. |  |
 | [`type_literal_in_constant_pattern`](https://dart.dev/lints/type_literal_in_constant_pattern) | Don't use constant patterns with type literals. | ✅ |
+| [`unintended_html_in_doc_comment`](https://dart.dev/lints/unintended_html_in_doc_comment) | Use of angle brackets in a doc comment is treated as HTML by Markdown. |  |
 | [`unnecessary_overrides`](https://dart.dev/lints/unnecessary_overrides) | Don't override a method to do a super method invocation with the same parameters. | ✅ |
 | [`unrelated_type_equality_checks`](https://dart.dev/lints/unrelated_type_equality_checks) | Equality operator `==` invocation with references of unrelated types. |  |
 | [`use_string_in_part_of_directives`](https://dart.dev/lints/use_string_in_part_of_directives) | Use string in part of directives. | ✅ |


### PR DESCRIPTION
- add `unintended_html_in_doc_comment` to core
- close https://github.com/dart-lang/lints/issues/192

cc @kevmoo @lrhn @kallentu 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
