### PR TITLE
Revert "Update README.md before archiving"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]  
-> This repo has moved to https://github.com/dart-lang/core/tree/main/pkgs/lints
-
 [![Build Status](https://github.com/dart-lang/lints/workflows/validate/badge.svg)](https://github.com/dart-lang/lints/actions?query=branch%3Amain)
 [![pub package](https://img.shields.io/pub/v/lints.svg)](https://pub.dev/packages/lints)
 [![package publisher](https://img.shields.io/pub/publisher/lints.svg)](https://pub.dev/packages/lints/publisher)


### PR DESCRIPTION
Reverts dart-lang/lints#214

Remove the archive note since the repro move is currently on pause.