### PR TITLE
update the sdk lower bound to the current stable

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,5 +12,3 @@ jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
-    with:
-      sdk: beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+## 5.1.1
+
+- Updated the SDK lower bound to 3.6.
+
 ## 5.1.0
 
 - `core`:
   - added [unintended_html_in_doc_comment] (https://github.com/dart-lang/lints/issues/192)
-- Updated the SDK lower-bound to 3.6.
+- Updated the SDK lower bound to 3.6 (dev).
 
 [unintended_html_in_doc_comment]: https://dart.dev/lints/unintended_html_in_doc_comment
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lints
-version: 5.1.0
+version: 5.1.1
 description: >
   Official Dart lint rules. Defines the 'core' and 'recommended' set of lints
   suggested by the Dart team.
@@ -10,7 +10,7 @@ topics:
   - lints
 
 environment:
-  sdk: ^3.6.0-0
+  sdk: ^3.6.0
 
 # NOTE: Code is not allowed in this package - do not add dependencies.
 # dependencies:

--- a/tool/rules.json
+++ b/tool/rules.json
@@ -110,6 +110,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "avoid_futureor_void",
+    "description": "Avoid using 'FutureOr<void>' as the type of a result.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "avoid_implementing_value_types",
     "description": "Don't implement classes that override `==`.",
     "fixStatus": "noFix"
@@ -585,6 +590,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "omit_obvious_property_types",
+    "description": "Omit obvious type annotations for top-level and static variables.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "one_member_abstracts",
     "description": "Avoid defining a one-member abstract class when a simple function will do.",
     "fixStatus": "noFix"
@@ -890,6 +900,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "specify_nonobvious_property_types",
+    "description": "Specify non-obvious type annotations for top-level and static variables.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "super_goes_last",
     "description": "Place the `super` call last in a constructor initialization list.",
     "fixStatus": "noFix"
@@ -1075,6 +1090,11 @@
     "fixStatus": "noFix"
   },
   {
+    "name": "unsafe_variance",
+    "description": "Unsafe type: Has a type variable in a non-covariant position.",
+    "fixStatus": "noFix"
+  },
+  {
     "name": "use_build_context_synchronously",
     "description": "Do not use `BuildContext` across asynchronous gaps.",
     "fixStatus": "noFix"
@@ -1082,7 +1102,7 @@
   {
     "name": "use_colored_box",
     "description": "Use `ColoredBox`.",
-    "fixStatus": "needsFix"
+    "fixStatus": "hasFix"
   },
   {
     "name": "use_decorated_box",


### PR DESCRIPTION
- update the sdk lower bound to the current stable

We can use stable as the current lower bound - instead of 3.6.0-0 (dev) - now that stable is out.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
